### PR TITLE
Get configuration from environment variables

### DIFF
--- a/pa_messenger/config.py
+++ b/pa_messenger/config.py
@@ -2,12 +2,12 @@ import os
 
 
 class DefaultConfig(object):
-    SECRET_KEY = 'youshouldreallychangethis'
+    SECRET_KEY = os.environ.get('SECRET_KEY')
     DEBUG = False
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql://mews:mews@localhost/mewsdb')
-    TWILIO_ACCOUNT_SID = ''
-    TWILIO_AUTH_TOKEN = ''
-    TWILIO_NUMBER = ''
+    TWILIO_ACCOUNT_SID = os.environ.get('TWILIO_ACCOUNT_SID')
+    TWILIO_AUTH_TOKEN = os.environ.get('TWILIO_AUTH_TOKEN')
+    TWILIO_NUMBER = os.environ.get('TWILIO_NUMBER')
     BASIC_AUTH_USERNAME = 'admin'
     BASIC_AUTH_PASSWORD = 'SoSecret'
 


### PR DESCRIPTION
Switch from using hardcoded environment variables to getting the same
settings from environment variables.

Without this change it's basically inevitable that people will hardcode
passwords and publish them on github.

To use these changes while deploying to Heroku, set heroku config vars
that correspond with each configuration setting instead of hardcoding
it.

I haven't tested this very well, just confirmed that syntax works at
all.

Merging this to my master branch because Chase hasn't merged it yet and I want to get it deployed.